### PR TITLE
Add inventory management endpoints

### DIFF
--- a/controllers/inventory.controller.js
+++ b/controllers/inventory.controller.js
@@ -1,0 +1,298 @@
+const Inventory = require('../models/inventory.model');
+const Lot = require('../models/lot.model');
+const StockTransaction = require('../models/stock-transaction.model');
+const asyncHandler = require('../utils/async-handler');
+const { SuccessResponse, CREATED } = require('../response/success.response');
+const { NotFoundError, BadRequestError } = require('../response/error.response');
+
+const groupLotsByProduct = (lots) => {
+  return lots.reduce((map, lot) => {
+    const pid = (lot.product?._id || lot.product).toString();
+    if (!map[pid]) map[pid] = [];
+    map[pid].push(lot);
+    return map;
+  }, {});
+};
+
+const getAllInventory = asyncHandler(async (req, res) => {
+  const inventories = await Inventory.find().sort({ updatedAt: -1 }).lean();
+
+  const productIds = inventories
+    .map((i) => i.product?._id || i.product)
+    .filter(Boolean);
+
+  const lots = await Lot.find({ product: { $in: productIds } })
+    .setOptions({ skipPopulate: true })
+    .sort({ createdAt: 1 })
+    .lean();
+
+  const lotsByProduct = groupLotsByProduct(lots);
+
+  const result = inventories.map((inv) => {
+    const pid = (inv.product?._id || inv.product)?.toString();
+    const productLots = lotsByProduct[pid] || [];
+    return {
+      ...inv,
+      lots: productLots,
+      total_quantity: productLots.reduce((s, l) => s + l.lot_quantity, 0),
+    };
+  });
+
+  new SuccessResponse({ metadata: result, res });
+});
+
+const getInventoryByProduct = asyncHandler(async (req, res) => {
+  const inventory = await Inventory.findOne({ product: req.params.productId }).lean();
+  if (!inventory) throw new NotFoundError('Không tìm thấy tồn kho cho sản phẩm này');
+
+  const lots = await Lot.find({ product: req.params.productId })
+    .setOptions({ skipPopulate: true })
+    .sort({ createdAt: 1 })
+    .lean();
+
+  inventory.lots = lots;
+  inventory.total_quantity = lots.reduce((s, l) => s + l.lot_quantity, 0);
+
+  new SuccessResponse({ metadata: inventory, res });
+});
+
+const getInventoryLots = asyncHandler(async (req, res) => {
+  const lots = await Lot.find({ product: req.params.productId })
+    .setOptions({ skipPopulate: true })
+    .sort({ createdAt: 1 })
+    .lean();
+  new SuccessResponse({ metadata: lots, res });
+});
+
+const createInventory = asyncHandler(async (req, res) => {
+  const { product, inventory_note, initial_lot } = req.body;
+
+  const existing = await Inventory.findOne({ product });
+  if (existing) throw new BadRequestError('Sản phẩm đã có trong kho');
+
+  let inventory = await Inventory.create({ product, inventory_note });
+
+  let createdLot = null;
+  if (initial_lot) {
+    try {
+      createdLot = await Lot.create({
+        product,
+        lot_code: initial_lot.lot_code,
+        lot_quantity: initial_lot.lot_quantity,
+        lot_purchase_price: initial_lot.lot_purchase_price,
+        lot_selling_price: initial_lot.lot_selling_price,
+        lot_note: initial_lot.lot_note || '',
+      });
+    } catch (err) {
+      try {
+        await Inventory.deleteOne({ _id: inventory._id });
+      } catch (rollbackErr) {
+        console.error(
+          '[inventory] CRITICAL: rollback inventory create failed',
+          { id: inventory._id, originalError: err?.message, rollbackError: rollbackErr?.message }
+        );
+      }
+      throw err;
+    }
+
+    try {
+      await StockTransaction.create({
+        product,
+        lot: createdLot._id,
+        lot_code: createdLot.lot_code,
+        transaction_type: 'stock_in',
+        transaction_quantity: createdLot.lot_quantity,
+        transaction_purchase_price: createdLot.lot_purchase_price,
+        transaction_selling_price: createdLot.lot_selling_price,
+        transaction_note: 'Khởi tạo kho',
+      });
+    } catch (err) {
+      try {
+        await Lot.deleteOne({ _id: createdLot._id });
+        await Inventory.deleteOne({ _id: inventory._id });
+      } catch (rollbackErr) {
+        console.error(
+          '[inventory] CRITICAL: rollback lot+inventory create failed',
+          { lotId: createdLot._id, inventoryId: inventory._id, originalError: err?.message, rollbackError: rollbackErr?.message }
+        );
+      }
+      throw err;
+    }
+  }
+
+  inventory = await Inventory.findById(inventory._id).lean();
+  const lots = await Lot.find({ product })
+    .setOptions({ skipPopulate: true })
+    .sort({ createdAt: 1 })
+    .lean();
+  inventory.lots = lots;
+  inventory.total_quantity = lots.reduce((s, l) => s + l.lot_quantity, 0);
+
+  new CREATED({ res, message: 'Đã thêm sản phẩm vào kho', metadata: inventory });
+});
+
+const updateInventory = asyncHandler(async (req, res) => {
+  const inventory = await Inventory.findByIdAndUpdate(req.params._id, req.body, {
+    new: true,
+    runValidators: true,
+  });
+  if (!inventory) throw new NotFoundError('Không tìm thấy tồn kho');
+  new SuccessResponse({ metadata: inventory, res });
+});
+
+const deleteInventory = asyncHandler(async (req, res) => {
+  const inventory = await Inventory.findByIdAndDelete(req.params._id).setOptions({ skipPopulate: true });
+  if (!inventory) throw new NotFoundError('Không tìm thấy tồn kho');
+  if (inventory.product) {
+    await Lot.deleteMany({ product: inventory.product });
+    await StockTransaction.deleteMany({ product: inventory.product });
+  }
+  return res.status(204).json({ status: 'success' });
+});
+
+const handleStockIn = async ({ product, lot_code, transaction_quantity, lot_purchase_price, lot_selling_price, transaction_note }) => {
+  const inventoryExists = await Inventory.exists({ product });
+  if (!inventoryExists) throw new NotFoundError('Sản phẩm chưa có trong kho');
+
+  let lot = await Lot.findOne({ product, lot_code }).setOptions({ skipPopulate: true });
+  let isNewLot = false;
+
+  if (lot) {
+    lot = await Lot.findOneAndUpdate(
+      { _id: lot._id },
+      { $inc: { lot_quantity: transaction_quantity } },
+      { new: true }
+    ).setOptions({ skipPopulate: true });
+  } else {
+    if (lot_purchase_price === undefined || lot_selling_price === undefined) {
+      throw new BadRequestError('Lô mới phải có giá mua vào và giá bán ra');
+    }
+    isNewLot = true;
+    lot = await Lot.create({
+      product,
+      lot_code,
+      lot_quantity: transaction_quantity,
+      lot_purchase_price,
+      lot_selling_price,
+    });
+  }
+
+  let transaction;
+  try {
+    transaction = await StockTransaction.create({
+      product,
+      lot: lot._id,
+      lot_code: lot.lot_code,
+      transaction_type: 'stock_in',
+      transaction_quantity,
+      transaction_purchase_price: lot.lot_purchase_price,
+      transaction_selling_price: lot.lot_selling_price,
+      transaction_note,
+    });
+  } catch (err) {
+    try {
+      if (isNewLot) {
+        await Lot.deleteOne({ _id: lot._id });
+      } else {
+        await Lot.updateOne(
+          { _id: lot._id },
+          { $inc: { lot_quantity: -transaction_quantity } }
+        );
+      }
+    } catch (rollbackErr) {
+      console.error(
+        '[inventory] CRITICAL: stock_in rollback failed',
+        { lotId: lot._id, isNewLot, originalError: err?.message, rollbackError: rollbackErr?.message }
+      );
+    }
+    throw err;
+  }
+
+  return { lot, transaction };
+};
+
+const handleStockOut = async ({ lot: lotId, transaction_quantity, transaction_note }) => {
+  const lot = await Lot.findOneAndUpdate(
+    { _id: lotId, lot_quantity: { $gte: transaction_quantity } },
+    { $inc: { lot_quantity: -transaction_quantity } },
+    { new: true }
+  ).setOptions({ skipPopulate: true });
+
+  if (!lot) {
+    const exists = await Lot.exists({ _id: lotId });
+    if (!exists) throw new NotFoundError('Không tìm thấy lô');
+    throw new BadRequestError('Số lượng xuất kho vượt quá tồn kho hiện tại');
+  }
+
+  let transaction;
+  try {
+    transaction = await StockTransaction.create({
+      product: lot.product,
+      lot: lot._id,
+      lot_code: lot.lot_code,
+      transaction_type: 'stock_out',
+      transaction_quantity,
+      transaction_purchase_price: lot.lot_purchase_price,
+      transaction_selling_price: lot.lot_selling_price,
+      transaction_note,
+    });
+  } catch (err) {
+    try {
+      await Lot.updateOne(
+        { _id: lot._id },
+        { $inc: { lot_quantity: transaction_quantity } }
+      );
+    } catch (rollbackErr) {
+      console.error(
+        '[inventory] CRITICAL: stock_out rollback failed',
+        { lotId: lot._id, originalError: err?.message, rollbackError: rollbackErr?.message }
+      );
+    }
+    throw err;
+  }
+
+  return { lot, transaction };
+};
+
+const processTransaction = asyncHandler(async (req, res) => {
+  const { transaction_type } = req.body;
+
+  let result;
+  if (transaction_type === 'stock_in') {
+    result = await handleStockIn(req.body);
+  } else {
+    result = await handleStockOut(req.body);
+  }
+
+  new CREATED({
+    res,
+    message: transaction_type === 'stock_in' ? 'Nhập kho thành công' : 'Xuất kho thành công',
+    metadata: result,
+  });
+});
+
+const getTransactions = asyncHandler(async (req, res) => {
+  const filter = {};
+  if (req.query.product) filter.product = req.query.product;
+  if (req.query.lot) filter.lot = req.query.lot;
+  if (req.query.type) filter.transaction_type = req.query.type;
+
+  const transactions = await StockTransaction.find(filter)
+    .select('-__v')
+    .sort({ createdAt: -1 })
+    .limit(100)
+    .lean();
+
+  new SuccessResponse({ metadata: transactions, res });
+});
+
+module.exports = {
+  getAllInventory,
+  getInventoryByProduct,
+  getInventoryLots,
+  createInventory,
+  updateInventory,
+  deleteInventory,
+  processTransaction,
+  getTransactions,
+};

--- a/models/inventory.model.js
+++ b/models/inventory.model.js
@@ -1,0 +1,27 @@
+const mongoose = require('mongoose');
+const DOCUMENT_NAME = 'Inventory';
+const COLLECTION_NAME = 'Inventories';
+
+const InventorySchema = new mongoose.Schema(
+  {
+    product: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Product',
+      required: true,
+    },
+    inventory_note: { type: String, default: '' },
+  },
+  { timestamps: true, collection: COLLECTION_NAME }
+);
+
+InventorySchema.index({ product: 1 }, { unique: true });
+
+InventorySchema.pre(/^find/, function () {
+  if (this.getOptions().skipPopulate) return;
+  this.populate({
+    path: 'product',
+    select: 'product_name product_slug product_cover_image brand category',
+  });
+});
+
+module.exports = mongoose.model(DOCUMENT_NAME, InventorySchema);

--- a/models/lot.model.js
+++ b/models/lot.model.js
@@ -1,0 +1,32 @@
+const mongoose = require('mongoose');
+const DOCUMENT_NAME = 'Lot';
+const COLLECTION_NAME = 'Lots';
+
+const LotSchema = new mongoose.Schema(
+  {
+    product: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Product',
+      required: true,
+    },
+    lot_code: { type: String, required: true, trim: true },
+    lot_quantity: { type: Number, required: true, default: 0, min: 0 },
+    lot_purchase_price: { type: Number, required: true, default: 0, min: 0 },
+    lot_selling_price: { type: Number, required: true, default: 0, min: 0 },
+    lot_note: { type: String, default: '' },
+  },
+  { timestamps: true, collection: COLLECTION_NAME }
+);
+
+LotSchema.index({ product: 1, lot_code: 1 }, { unique: true });
+LotSchema.index({ product: 1 });
+
+LotSchema.pre(/^find/, function () {
+  if (this.getOptions().skipPopulate) return;
+  this.populate({
+    path: 'product',
+    select: 'product_name product_slug product_cover_image brand category',
+  });
+});
+
+module.exports = mongoose.model(DOCUMENT_NAME, LotSchema);

--- a/models/stock-transaction.model.js
+++ b/models/stock-transaction.model.js
@@ -1,0 +1,43 @@
+const mongoose = require('mongoose');
+const DOCUMENT_NAME = 'StockTransaction';
+const COLLECTION_NAME = 'StockTransactions';
+
+const StockTransactionSchema = new mongoose.Schema(
+  {
+    product: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Product',
+      required: true,
+    },
+    lot: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Lot',
+      default: null,
+    },
+    lot_code: { type: String, default: '', trim: true },
+    transaction_type: {
+      type: String,
+      enum: ['stock_in', 'stock_out'],
+      required: true,
+    },
+    transaction_quantity: { type: Number, required: true, min: 1 },
+    transaction_purchase_price: { type: Number, default: 0, min: 0 },
+    transaction_selling_price: { type: Number, default: 0, min: 0 },
+    transaction_note: { type: String, default: '' },
+  },
+  { timestamps: true, collection: COLLECTION_NAME }
+);
+
+StockTransactionSchema.index({ product: 1 });
+StockTransactionSchema.index({ lot: 1 });
+StockTransactionSchema.index({ createdAt: -1 });
+
+StockTransactionSchema.pre(/^find/, function () {
+  if (this.getOptions().skipPopulate) return;
+  this.populate({
+    path: 'product',
+    select: 'product_name product_slug product_cover_image',
+  });
+});
+
+module.exports = mongoose.model(DOCUMENT_NAME, StockTransactionSchema);

--- a/routes/api.js
+++ b/routes/api.js
@@ -7,6 +7,7 @@ const projectRouter = require('./projects.router');
 const videoRouter = require('./video.router');
 const authRouter = require('./auth.router');
 const counterRouter = require('./counter.router');
+const inventoryRouter = require('./inventory.router');
 const router = express.Router();
 
 router.use('/categories', categoriesRouter);
@@ -17,5 +18,6 @@ router.use('/brands', brandRouter);
 router.use('/projects', projectRouter);
 router.use('/video', videoRouter);
 router.use('/counter', counterRouter);
+router.use('/inventory', inventoryRouter);
 
 module.exports = router;

--- a/routes/inventory.router.js
+++ b/routes/inventory.router.js
@@ -1,0 +1,40 @@
+const express = require('express');
+const inventoryController = require('../controllers/inventory.controller');
+const { authentication, authorization } = require('../middlewares/auth.middlewares');
+const { validateRequest } = require('../middlewares/validate-request');
+const {
+  createInventorySchema,
+  updateInventorySchema,
+  stockTransactionSchema,
+} = require('../validations/inventory.validation');
+
+const router = express.Router();
+
+router.use(authentication, authorization('admin', 'moderator'));
+
+router.get('/', inventoryController.getAllInventory);
+router.get('/product/:productId', inventoryController.getInventoryByProduct);
+router.get('/product/:productId/lots', inventoryController.getInventoryLots);
+router.get('/transactions', inventoryController.getTransactions);
+
+router.post(
+  '/',
+  validateRequest(createInventorySchema),
+  inventoryController.createInventory
+);
+
+router.post(
+  '/transaction',
+  validateRequest(stockTransactionSchema),
+  inventoryController.processTransaction
+);
+
+router.patch(
+  '/:_id',
+  validateRequest(updateInventorySchema),
+  inventoryController.updateInventory
+);
+
+router.delete('/:_id', inventoryController.deleteInventory);
+
+module.exports = router;

--- a/scripts/migrate-inventory-lots.js
+++ b/scripts/migrate-inventory-lots.js
@@ -1,0 +1,116 @@
+/**
+ * Migrate legacy Inventory schema (with embedded quantity/prices) to lot-based model.
+ *
+ * For each Inventory:
+ *   - If legacy fields exist with quantity > 0, create a Lot { lot_code: 'MIGRATED', ... } using the old data.
+ *   - Strip legacy fields (inventory_quantity, inventory_purchase_price, inventory_selling_price) from Inventory doc.
+ * For each StockTransaction with old `transaction_lot` string:
+ *   - Try to match a Lot by (product, lot_code). Set tx.lot = lot._id, tx.lot_code = matched lot_code.
+ *   - If no match, set tx.lot_code = transaction_lot (preserve as snapshot), tx.lot = null.
+ *   - Unset legacy `transaction_lot` field.
+ *
+ * Idempotent: re-running is safe.
+ *
+ * Usage: node scripts/migrate-inventory-lots.js
+ */
+
+const mongoose = require('mongoose');
+const Inventory = require('../models/inventory.model');
+const Lot = require('../models/lot.model');
+const StockTransaction = require('../models/stock-transaction.model');
+
+const DB_URI = process.env.DB_URI || 'mongodb://127.0.0.1:27017/lttn-db';
+
+async function migrate() {
+  await mongoose.connect(DB_URI);
+  console.log('[migrate] connected to', DB_URI);
+
+  const inventoriesCol = mongoose.connection.collection('Inventories');
+  const stockTxCol = mongoose.connection.collection('StockTransactions');
+
+  // === Step 1: Migrate Inventory legacy fields → Lot ===
+  const legacyInventories = await inventoriesCol
+    .find({ inventory_quantity: { $exists: true } })
+    .toArray();
+
+  console.log(`[migrate] found ${legacyInventories.length} legacy inventories`);
+
+  let lotsCreated = 0;
+  for (const inv of legacyInventories) {
+    const qty = inv.inventory_quantity || 0;
+    if (qty > 0) {
+      const existing = await Lot.findOne({ product: inv.product, lot_code: 'MIGRATED' })
+        .setOptions({ skipPopulate: true });
+      if (!existing) {
+        await Lot.create({
+          product: inv.product,
+          lot_code: 'MIGRATED',
+          lot_quantity: qty,
+          lot_purchase_price: inv.inventory_purchase_price || 0,
+          lot_selling_price: inv.inventory_selling_price || 0,
+          lot_note: 'Tạo tự động khi migrate sang model lot-based',
+        });
+        lotsCreated++;
+      }
+    }
+
+    await inventoriesCol.updateOne(
+      { _id: inv._id },
+      {
+        $unset: {
+          inventory_quantity: '',
+          inventory_purchase_price: '',
+          inventory_selling_price: '',
+        },
+      }
+    );
+  }
+  console.log(`[migrate] created ${lotsCreated} Lots, stripped legacy fields from ${legacyInventories.length} Inventories`);
+
+  // === Step 2: Backfill StockTransaction.lot / lot_code ===
+  const legacyTxs = await stockTxCol
+    .find({ transaction_lot: { $exists: true } })
+    .toArray();
+
+  console.log(`[migrate] found ${legacyTxs.length} legacy transactions`);
+
+  let txMatched = 0;
+  let txOrphan = 0;
+  for (const tx of legacyTxs) {
+    const lotCode = tx.transaction_lot || '';
+    let lotRef = null;
+    let lotCodeSnapshot = lotCode;
+
+    if (lotCode) {
+      const matched = await Lot.findOne({ product: tx.product, lot_code: lotCode })
+        .setOptions({ skipPopulate: true });
+      if (matched) {
+        lotRef = matched._id;
+        lotCodeSnapshot = matched.lot_code;
+        txMatched++;
+      } else {
+        txOrphan++;
+      }
+    }
+
+    await stockTxCol.updateOne(
+      { _id: tx._id },
+      {
+        $set: {
+          lot: lotRef,
+          lot_code: lotCodeSnapshot,
+        },
+        $unset: { transaction_lot: '' },
+      }
+    );
+  }
+  console.log(`[migrate] backfilled transactions: ${txMatched} matched to lots, ${txOrphan} orphan (lot_code preserved as snapshot)`);
+
+  await mongoose.disconnect();
+  console.log('[migrate] done');
+}
+
+migrate().catch((err) => {
+  console.error('[migrate] FAILED', err);
+  process.exit(1);
+});

--- a/validations/inventory.validation.js
+++ b/validations/inventory.validation.js
@@ -1,0 +1,103 @@
+const Joi = require('joi');
+
+const objectId = Joi.string().hex().length(24);
+
+const initialLotSchema = Joi.object({
+  lot_code: Joi.string().trim().required().messages({
+    'any.required': 'Vui lòng nhập số lô',
+    'string.empty': 'Vui lòng nhập số lô',
+  }),
+  lot_quantity: Joi.number().integer().min(1).required().messages({
+    'any.required': 'Vui lòng nhập số lượng lô',
+    'number.base': 'Số lượng phải là số',
+    'number.integer': 'Số lượng phải là số nguyên',
+    'number.min': 'Số lượng phải >= 1',
+  }),
+  lot_purchase_price: Joi.number().min(0).required().messages({
+    'any.required': 'Vui lòng nhập giá mua vào',
+    'number.base': 'Mua vào phải là số',
+    'number.min': 'Mua vào phải >= 0',
+  }),
+  lot_selling_price: Joi.number().min(0).required().messages({
+    'any.required': 'Vui lòng nhập giá bán ra',
+    'number.base': 'Bán ra phải là số',
+    'number.min': 'Bán ra phải >= 0',
+  }),
+  lot_note: Joi.string().allow('', null),
+});
+
+const createInventorySchema = Joi.object({
+  product: objectId.required().messages({
+    'any.required': 'Vui lòng chọn sản phẩm',
+    'string.empty': 'Vui lòng chọn sản phẩm',
+    'string.hex': 'Sản phẩm không hợp lệ',
+    'string.length': 'Sản phẩm không hợp lệ',
+  }),
+  inventory_note: Joi.string().allow('', null),
+  initial_lot: initialLotSchema.required().messages({
+    'any.required': 'Vui lòng tạo lô đầu tiên',
+  }),
+});
+
+const updateInventorySchema = Joi.object({
+  inventory_note: Joi.string().allow('', null),
+}).min(1).messages({
+  'object.min': 'Vui lòng cung cấp ít nhất một trường để cập nhật',
+});
+
+const stockInSchema = Joi.object({
+  transaction_type: Joi.string().valid('stock_in').required(),
+  product: objectId.required().messages({
+    'any.required': 'Vui lòng chọn sản phẩm',
+    'string.hex': 'Sản phẩm không hợp lệ',
+    'string.length': 'Sản phẩm không hợp lệ',
+  }),
+  lot_code: Joi.string().trim().required().messages({
+    'any.required': 'Vui lòng nhập số lô',
+    'string.empty': 'Vui lòng nhập số lô',
+  }),
+  transaction_quantity: Joi.number().integer().min(1).required().messages({
+    'any.required': 'Vui lòng nhập số lượng',
+    'number.base': 'Số lượng phải là số',
+    'number.integer': 'Số lượng phải là số nguyên',
+    'number.min': 'Số lượng phải >= 1',
+  }),
+  lot_purchase_price: Joi.number().min(0).messages({
+    'number.base': 'Mua vào phải là số',
+    'number.min': 'Mua vào phải >= 0',
+  }),
+  lot_selling_price: Joi.number().min(0).messages({
+    'number.base': 'Bán ra phải là số',
+    'number.min': 'Bán ra phải >= 0',
+  }),
+  transaction_note: Joi.string().allow('', null),
+});
+
+const stockOutSchema = Joi.object({
+  transaction_type: Joi.string().valid('stock_out').required(),
+  lot: objectId.required().messages({
+    'any.required': 'Vui lòng chọn lô để xuất',
+    'string.hex': 'Lô không hợp lệ',
+    'string.length': 'Lô không hợp lệ',
+  }),
+  transaction_quantity: Joi.number().integer().min(1).required().messages({
+    'any.required': 'Vui lòng nhập số lượng',
+    'number.base': 'Số lượng phải là số',
+    'number.integer': 'Số lượng phải là số nguyên',
+    'number.min': 'Số lượng phải >= 1',
+  }),
+  transaction_note: Joi.string().allow('', null),
+});
+
+const stockTransactionSchema = Joi.alternatives()
+  .conditional('.transaction_type', {
+    is: 'stock_in',
+    then: stockInSchema,
+    otherwise: stockOutSchema,
+  });
+
+module.exports = {
+  createInventorySchema,
+  updateInventorySchema,
+  stockTransactionSchema,
+};


### PR DESCRIPTION
## Summary
- New models: `Inventory`, `Lot`, `StockTransaction` for warehouse tracking
- `/api/v1/inventory` routes: list, create, delete, fetch lots, process transactions, transaction history
- Joi validation: `initial_lot` is now required when creating an inventory entry
- Migration script for existing inventory data into the new lot-based structure

## Test plan
- [ ] `POST /api/v1/inventory` without `initial_lot` returns 400 with message "Vui lòng tạo lô đầu tiên"
- [ ] `POST /api/v1/inventory` with full `initial_lot` creates inventory + first lot
- [ ] `POST /api/v1/inventory/transaction` (stock_in) on existing lot code adds to existing lot
- [ ] `POST /api/v1/inventory/transaction` (stock_in) on new lot code creates a new lot with prices
- [ ] `POST /api/v1/inventory/transaction` (stock_out) decrements lot quantity, blocks oversell
- [ ] `GET /api/v1/inventory/transactions` returns history sorted by time desc
- [ ] `DELETE /api/v1/inventory/:id` cascades and removes all lots + transactions
- [ ] Migration script runs cleanly on existing data